### PR TITLE
Update load_training_sample.py

### DIFF
--- a/load_data/load_training_sample.py
+++ b/load_data/load_training_sample.py
@@ -4,6 +4,7 @@ import scipy.sparse as sp
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import os
 
 
 
@@ -57,7 +58,7 @@ def load_data(dataset, path=data_path):
     
     print('Loading {} dataset...'.format(dataset))
     
-    idx_features_labels = np.genfromtxt("{}{}.content".format(path, '/'+dataset),
+    idx_features_labels = np.genfromtxt("{}.content".format(os.path.join(path, dataset)),
                                         dtype=np.dtype(str))
     features = sp.csr_matrix(idx_features_labels[:, 1:-2], dtype=np.float32)
     
@@ -70,7 +71,7 @@ def load_data(dataset, path=data_path):
     # build graph
     idx = np.array(idx_features_labels[:, 0], dtype=np.int32)
     idx_map = {j: i for i, j in enumerate(idx)}
-    edges_unordered = np.genfromtxt("{}{}.cites".format(path, '/'+dataset),
+    edges_unordered = np.genfromtxt("{}.cites".format(os.path.join(path, dataset)),
                                     dtype=np.float32)  
     edges = np.array(list(map(idx_map.get, edges_unordered.flatten())),
                      dtype=np.int32).reshape(edges_unordered.shape)


### PR DESCRIPTION
os.path.join(path, dataset) can adapt to both '/' and '\' in file paths.